### PR TITLE
Fix windows wheel build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto eol=lf
+
 protovalidate/_gen/** linguist-generated=true
 test/gen/** linguist-generated=true
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
           SCCACHE_DIR: ${{ github.workspace }}/.sccache
           SCCACHE_CACHE_SIZE: 250M
         with:
-          args: --release --out dist -i 3.10 -i 3.14t --features pyo3/generate-import-lib
+          args: --release --out dist -i 3.10 -i 3.14t
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
The feature has already been deprecated as a noop in recent pyo3 but problematically replaced the abi3 feature in pyproject.toml instead of adding to it

Also makes git checkouts, sdist and wheels use consistent line endings across OSes as typical in modern projects