### PR TITLE
Fix type annotation for Message for strict checkers

### DIFF
--- a/protovalidate/__init__.py
+++ b/protovalidate/__init__.py
@@ -23,7 +23,7 @@ always had.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ._errors import CompilationError, EvaluationError, ValidationError
 from ._gen.buf.validate.validate_pb import (
@@ -42,7 +42,7 @@ _default_validator = Validator()
 
 
 def validate(
-    message: Message | google_message.Message, *, fail_fast: bool = False
+    message: Message[Any] | google_message.Message, *, fail_fast: bool = False
 ) -> None:
     """Validates the given message against the static rules defined in the message's descriptor using a shared validator.
 
@@ -60,7 +60,7 @@ def validate(
 
 
 def collect_violations(
-    message: Message | google_message.Message, *, fail_fast: bool = False
+    message: Message[Any] | google_message.Message, *, fail_fast: bool = False
 ) -> list[Violation]:
     """Collects the violations for the given message against the static rules defined in the message's descriptor using a shared validator.
 

--- a/protovalidate/_protovalidate.pyi
+++ b/protovalidate/_protovalidate.pyi
@@ -42,7 +42,7 @@ class Validator:
                 predefined-rule extensions. If omitted, only standard rules are applied.
         """
     def collect_violations(
-        self, /, message: Message2 | Message, *, fail_fast: bool = False
+        self, /, message: Message2[Any] | Message, *, fail_fast: bool = False
     ) -> list[Violation]:
         """Validates the given message against the static rules defined in the message's descriptor.
 
@@ -64,7 +64,7 @@ class Validator:
             EvaluationError: If a rule failed while being evaluated.
         """
     def validate(
-        self, /, message: Message2 | Message, *, fail_fast: bool = False
+        self, /, message: Message2[Any] | Message, *, fail_fast: bool = False
     ) -> None:
         """Validate the given message against the static rules defined in the message's descriptor.
 

--- a/src/hints.rs
+++ b/src/hints.rs
@@ -34,7 +34,10 @@ impl<'a, 'py> FromPyObject<'a, 'py> for PbMessage<'a, 'py> {
     type Error = Infallible;
 
     const INPUT_TYPE: PyStaticExpr = type_hint_union!(
-        type_hint_identifier!("protobuf", "Message"),
+        type_hint_subscript!(
+            type_hint_identifier!("protobuf", "Message"),
+            type_hint_identifier!("typing", "Any")
+        ),
         type_hint_identifier!("google.protobuf.message", "Message")
     );
 


### PR DESCRIPTION
Fixes #522 

I think there is a protobuf-py side improvement possible to make this properly optional, will separately investigate it